### PR TITLE
Nextflow launch v2

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/cli/CmdLaunch.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/CmdLaunch.groovy
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nextflow.cli
+
+import com.beust.jcommander.DynamicParameter
+import com.beust.jcommander.Parameter
+import com.beust.jcommander.Parameters
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import nextflow.exception.AbortOperationException
+import nextflow.plugin.Plugins
+import org.pf4j.ExtensionPoint
+
+/**
+ * Implements the 'nextflow launch' command
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+@Parameters(commandDescription = "Launch a workflow in Seqera Platform")
+class CmdLaunch extends CmdBase implements UsageAware {
+
+    interface LaunchCommand extends ExtensionPoint {
+        void launch(LaunchOptions options)
+    }
+
+    static final public String NAME = 'launch'
+
+    @Override
+    String getName() { NAME }
+
+    @Parameter(description = 'Pipeline repository URL')
+    List<String> args
+
+    @Parameter(names = ['-workspace'], description = 'Workspace name')
+    String workspace
+
+    @Parameter(names = ['-compute-env'], description = 'Compute environment name')
+    String computeEnv
+
+    @Parameter(names = ['-name'], description = 'Assign a mnemonic name to the pipeline run')
+    String runName
+
+    @Parameter(names = ['-w', '-work-dir'], description = 'Directory where intermediate result files are stored')
+    String workDir
+
+    @Parameter(names = ['-r', '-revision'], description = 'Revision of the project to run (either a git branch, tag or commit SHA number)')
+    String revision
+
+    @Parameter(names = ['-profile'], description = 'Choose a configuration profile')
+    String profile
+
+    @Parameter(names = ['-c', '-config'], description = 'Add the specified file to configuration set')
+    List<String> configFiles
+
+    @Parameter(names = ['-params-file'], description = 'Load script parameters from a JSON/YAML file')
+    String paramsFile
+
+    @Parameter(names = ['-entry'], description = 'Entry workflow name to be executed')
+    String entryName
+
+    @Parameter(names = ['-resume'], description = 'Execute the script using the cached results')
+    String resume
+
+    @Parameter(names = ['-latest'], description = 'Pull latest changes before run')
+    boolean latest
+
+    @Parameter(names = ['-stub-run', '-stub'], description = 'Execute the workflow replacing process scripts with command stubs')
+    boolean stubRun
+
+    @Parameter(names = ['-main-script'], description = 'The script file to be executed when launching a project directory or repository')
+    String mainScript
+
+    /**
+     * Defines the parameters to be passed to the pipeline script
+     */
+    @DynamicParameter(names = '--', description = 'Set a parameter used by the pipeline', hidden = true)
+    Map<String, String> params = new LinkedHashMap<>()
+
+    private LaunchCommand operation
+
+    @Override
+    void run() {
+        // Validate required parameters
+        if (!args || args.isEmpty()) {
+            log.debug "No pipeline repository URL provided"
+            throw new AbortOperationException("Pipeline repository URL is required")
+        }
+
+        // Load the Launch command implementation
+        this.operation = loadOperation()
+        if (!operation)
+            throw new IllegalStateException("Unable to load launch extension.")
+
+        // Create options object
+        final options = new LaunchOptions(
+            pipeline: args[0],
+            workspace: workspace,
+            computeEnv: computeEnv,
+            runName: runName,
+            workDir: workDir,
+            revision: revision,
+            profile: profile,
+            configFiles: configFiles,
+            paramsFile: paramsFile,
+            entryName: entryName,
+            resume: resume,
+            latest: latest,
+            stubRun: stubRun,
+            mainScript: mainScript,
+            params: params,
+            launcher: launcher
+        )
+
+        // Execute launch
+        operation.launch(options)
+    }
+
+    @Override
+    void usage() {
+        usage(null)
+    }
+
+    @Override
+    void usage(List<String> args) {
+        def result = []
+        result << this.getClass().getAnnotation(Parameters).commandDescription()
+        result << 'Usage: nextflow launch <pipeline> [options]'
+        result << ''
+        result << 'Options:'
+        result << '  -workspace <name>         Workspace name'
+        result << '  -compute-env <name>       Compute environment name (default: primary)'
+        result << '  -name <name>              Assign a mnemonic name to the pipeline run'
+        result << '  -w, -work-dir <path>      Directory where intermediate result files are stored'
+        result << '  -r, -revision <revision>  Revision of the project to run (git branch, tag or commit SHA)'
+        result << '  -profile <profile>        Choose a configuration profile'
+        result << '  -c, -config <file>        Add the specified file to configuration set'
+        result << '  -params-file <file>       Load script parameters from a JSON/YAML file'
+        result << '  -entry <name>             Entry workflow name to be executed'
+        result << '  -resume [session]         Execute the script using the cached results'
+        result << '  -latest                   Pull latest changes before run'
+        result << '  -stub-run, -stub          Execute the workflow replacing process scripts with command stubs'
+        result << '  -main-script <file>       The script file to be executed when launching a project'
+        result << '  --<param>=<value>         Set a parameter used by the pipeline'
+        result << ''
+        println result.join('\n').toString()
+    }
+
+    protected LaunchCommand loadOperation() {
+        // Setup the plugins system and load the launch provider
+        Plugins.init()
+        // Load the config
+        Plugins.start('nf-tower')
+        // Get Launch command operations implementation from plugins
+        return Plugins.getExtension(LaunchCommand)
+    }
+
+    /**
+     * Data class to hold launch options
+     */
+    @CompileStatic
+    static class LaunchOptions {
+        String pipeline
+        String workspace
+        String computeEnv
+        String runName
+        String workDir
+        String revision
+        String profile
+        List<String> configFiles
+        String paramsFile
+        String entryName
+        String resume
+        boolean latest
+        boolean stubRun
+        String mainScript
+        Map<String, String> params
+        Launcher launcher
+    }
+}

--- a/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/cli/Launcher.groovy
@@ -96,6 +96,7 @@ class Launcher {
                 new CmdConsole(),
                 new CmdFs(),
                 new CmdInfo(),
+                new CmdLaunch(),
                 new CmdList(),
                 new CmdLog(),
                 new CmdPull(),
@@ -180,7 +181,7 @@ class Launcher {
         if( !options.logFile ) {
             if( isDaemon() )
                 options.logFile = System.getenv('NXF_LOG_FILE') ?: '.node-nextflow.log'
-            else if( command instanceof CmdRun || options.debug || options.trace )
+            else if( command instanceof CmdRun || command instanceof CmdLaunch || command instanceof CmdAuth || options.debug || options.trace )
                 options.logFile = System.getenv('NXF_LOG_FILE') ?: ".nextflow.log"
         }
     }

--- a/plugins/nf-tower/build.gradle
+++ b/plugins/nf-tower/build.gradle
@@ -25,7 +25,8 @@ nextflowPlugin {
         'io.seqera.tower.plugin.TowerConfig',
         'io.seqera.tower.plugin.TowerFactory',
         'io.seqera.tower.plugin.TowerFusionToken',
-        'io.seqera.tower.plugin.cli.AuthCommandImpl'
+        'io.seqera.tower.plugin.cli.AuthCommandImpl',
+        'io.seqera.tower.plugin.cli.LaunchCommandImpl'
     ]
 }
 

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/AuthCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/AuthCommandImpl.groovy
@@ -6,6 +6,7 @@ import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.seqera.http.HxClient
+import io.seqera.tower.plugin.TowerClient
 import nextflow.Const
 import nextflow.SysEnv
 import nextflow.cli.CmdAuth
@@ -30,7 +31,6 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
     static final int AUTH_POLL_TIMEOUT_RETRIES = 60
     static final int AUTH_POLL_INTERVAL_SECONDS = 5
     static final int WORKSPACE_SELECTION_THRESHOLD = 8  // Max workspaces to show in single list; above this uses org-first selection
-    private static final String DEFAULT_API_ENDPOINT = 'https://api.cloud.seqera.io'
 
     private static final Map SEQERA_API_TO_AUTH0 = [
         'https://api.cloud.dev-seqera.io'  : [
@@ -335,7 +335,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
 
     private String normalizeApiUrl(String url) {
         if( !url ) {
-            return DEFAULT_API_ENDPOINT
+            return TowerClient.DEF_ENDPOINT_URL
         }
         if( !url.startsWith('http://') && !url.startsWith('https://') ) {
             return 'https://' + url
@@ -392,7 +392,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         // Read token from seqera_auth.config file
         final authConfig = readAuthFile()
         final existingToken = authConfig['tower.accessToken']
-        final apiUrl = authConfig['tower.endpoint'] as String ?: DEFAULT_API_ENDPOINT
+        final apiUrl = authConfig['tower.endpoint'] as String ?: TowerClient.DEF_ENDPOINT_URL
 
         if( !existingToken ) {
             ColorUtil.printColored("WARN: No authentication token found in auth file.", "yellow bold")
@@ -516,7 +516,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
 
         // Token can come from seqera_auth.config file or environment variable
         final existingToken = config['tower.accessToken'] ?: SysEnv.get('TOWER_ACCESS_TOKEN')
-        final endpoint = config['tower.endpoint'] ?: DEFAULT_API_ENDPOINT
+        final endpoint = config['tower.endpoint'] ?: TowerClient.DEF_ENDPOINT_URL
 
         if( !existingToken ) {
             println "No authentication found. Please run ${ColorUtil.colorize('nextflow auth login', 'cyan')} first."
@@ -964,7 +964,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         final status = new ConfigStatus([], null, null)
 
         // API endpoint
-        final endpointInfo = getConfigValue(config, authConfig, 'tower.endpoint', 'TOWER_API_ENDPOINT', DEFAULT_API_ENDPOINT)
+        final endpointInfo = getConfigValue(config, authConfig, 'tower.endpoint', 'TOWER_API_ENDPOINT', TowerClient.DEF_ENDPOINT_URL)
         status.table.add(['API endpoint', ColorUtil.colorize(endpointInfo.value as String, 'magenta'), endpointInfo.source as String])
 
         // API connection check

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/AuthCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/AuthCommandImpl.groovy
@@ -289,7 +289,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         ColorUtil.printColored("Personal Access Token saved to Nextflow auth config (${getAuthFile().toString()})", "green")
     }
 
-    private String getWebUrlFromApiEndpoint(String apiEndpoint) {
+    protected String getWebUrlFromApiEndpoint(String apiEndpoint) {
         // Convert API endpoint to web URL
         // e.g., https://api.cloud.seqera.io -> https://cloud.seqera.io
         //      https://cloud.seqera.io/api -> https://cloud.seqera.io
@@ -777,7 +777,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         return [changed: currentId != selectedId, metadata: metadata]
     }
 
-    private List getUserWorkspaces(String accessToken, String endpoint, String userId) {
+    protected List getUserWorkspaces(String accessToken, String endpoint, String userId) {
         final client = createHttpClient(accessToken)
         final request = HttpRequest.newBuilder()
             .uri(URI.create("${endpoint}/user/${userId}/workspaces"))
@@ -1073,7 +1073,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         tableLines.each { println it }
     }
 
-    private List<String> generateStatusTableLines(List<List<String>> rows) {
+    protected List<String> generateStatusTableLines(List<List<String>> rows) {
         if( !rows ) return []
 
         final List<String> lines = []
@@ -1267,7 +1267,7 @@ class AuthCommandImpl implements CmdAuth.AuthCommand {
         }
     }
 
-    private Map readConfig() {
+    protected Map readConfig() {
         final builder = new ConfigBuilder().setHomeDir(Const.APP_HOME_DIR).setCurrentDir(Const.APP_HOME_DIR)
         return builder.buildConfigObject().flatten()
     }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
@@ -21,6 +21,7 @@ import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.seqera.http.HxClient
+import io.seqera.tower.plugin.TowerClient
 import nextflow.BuildInfo
 import nextflow.cli.CmdLaunch
 import nextflow.cli.ColorUtil
@@ -51,7 +52,6 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
     static final public List<String> VALID_PARAMS_FILE = ['json', 'yml', 'yaml']
     static final private Pattern DOT_ESCAPED = ~/\\\./
     static final private Pattern DOT_NOT_ESCAPED = ~/(?<!\\)\./
-    static final private String DEFAULT_API_ENDPOINT = 'https://api.cloud.seqera.io'
     static final int API_TIMEOUT_MS = 10000
 
     // Delegate to AuthCommandImpl for shared authentication and API functionality
@@ -78,7 +78,7 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
 
         // Load configuration to get authentication and endpoint
         final config = authHelper.readConfig()
-        final apiEndpoint = (config['tower.endpoint'] ?: DEFAULT_API_ENDPOINT) as String
+        final apiEndpoint = (config['tower.endpoint'] ?: TowerClient.DEF_ENDPOINT_URL) as String
         final accessToken = config['tower.accessToken'] as String
 
         if (!accessToken) {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
@@ -561,11 +561,10 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
             }
 
             // Print final status after logs
-            if (finalStatus && firstLogReceived) {
-                println ""
-                println ('─' * 70)
-                println ""
-                println formatWorkflowStatus(finalStatus)
+            if (finalStatus) {
+                def colorName = getColorForStatus(finalStatus)
+                def coloredIcon = (colorName == 'cyan') ? '⠿' : ColorUtil.colorize('⠿', colorName)
+                println "${coloredIcon} ${formatWorkflowStatus(finalStatus)}"
             }
         }
     }
@@ -576,9 +575,14 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
     private String getSpinnerMode(String status, boolean workflowFinished) {
         if (!status) return 'waiting'
 
-        // Use finished animation for final statuses
-        if (status == 'SUCCEEDED' || status == 'FAILED' || status == 'CANCELLED' || status == 'ABORTED' || status == 'UNKNOWN') {
-            return 'finished'
+        // Use succeeded animation for successful completion
+        if (status == 'SUCCEEDED') {
+            return 'succeeded'
+        }
+
+        // Use failed animation for failed/cancelled/aborted statuses
+        if (status == 'FAILED' || status == 'CANCELLED' || status == 'ABORTED' || status == 'UNKNOWN') {
+            return 'failed'
         }
 
         // Use waiting animation for pending/submitted

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
@@ -1,0 +1,858 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.plugin.cli
+
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
+import io.seqera.http.HxClient
+import nextflow.BuildInfo
+import nextflow.cli.CmdLaunch
+import nextflow.cli.ColorUtil
+import nextflow.config.ConfigBuilder
+import nextflow.exception.AbortOperationException
+import nextflow.file.FileHelper
+import nextflow.scm.AssetManager
+import org.yaml.snakeyaml.Yaml
+
+import java.io.FileNotFoundException
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.regex.Pattern
+
+/**
+ * CLI sub-command LAUNCH -- Launch a workflow in Seqera Platform
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+@Slf4j
+@CompileStatic
+class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
+
+    static final public List<String> VALID_PARAMS_FILE = ['json', 'yml', 'yaml']
+    static final private Pattern DOT_ESCAPED = ~/\\\./
+    static final private Pattern DOT_NOT_ESCAPED = ~/(?<!\\)\./
+    static final private String DEFAULT_API_ENDPOINT = 'https://api.cloud.seqera.io'
+    static final int API_TIMEOUT_MS = 10000
+
+    @Override
+    void launch(CmdLaunch.LaunchOptions options) {
+        printBanner(options)
+
+        log.debug "Executing 'nextflow launch' command"
+
+        final pipeline = options.pipeline
+        log.debug "Pipeline repository: ${pipeline}"
+
+        // Reject local file paths
+        if (isLocalPath(pipeline)) {
+            log.debug "Rejecting local file path: ${pipeline}"
+            throw new AbortOperationException("Local file paths are not supported. Please provide a remote repository URL.")
+        }
+
+        // Resolve repository URL using AssetManager (same as nextflow run)
+        String resolvedPipelineUrl = resolvePipelineUrl(pipeline)
+        log.debug "Resolved pipeline URL: ${resolvedPipelineUrl}"
+
+        // Load configuration to get authentication and endpoint
+        final config = readConfig()
+        final apiEndpoint = (config['tower.endpoint'] ?: DEFAULT_API_ENDPOINT) as String
+        final accessToken = config['tower.accessToken'] as String
+
+        if (!accessToken) {
+            throw new AbortOperationException("No authentication found. Please run 'nextflow auth login' first.")
+        }
+
+        // Get workspace info
+        final workspaceId = resolveWorkspaceId(config, options.workspace, accessToken, apiEndpoint)
+        final userName = getUserName(accessToken, apiEndpoint)
+
+        String orgName = null
+        String workspaceName = null
+        if (workspaceId) {
+            final wsDetails = getWorkspaceDetails(accessToken, apiEndpoint, workspaceId)
+            orgName = wsDetails?.orgName as String
+            workspaceName = wsDetails?.workspaceName as String
+            log.debug "Using workspace '${workspaceName}' (ID: ${workspaceId})"
+        } else {
+            log.debug "Using personal workspace for user: ${userName}"
+        }
+
+        // Find compute environment
+        log.debug "Looking up compute environment: ${options.computeEnv ?: '(primary)'}"
+        def computeEnvInfo = findComputeEnv(options.computeEnv, workspaceId, accessToken, apiEndpoint)
+        if (!computeEnvInfo) {
+            if (options.computeEnv) {
+                throw new AbortOperationException("Compute environment '${options.computeEnv}' not found")
+            } else {
+                throw new AbortOperationException("No primary compute environment found")
+            }
+        }
+        String computeEnvId = computeEnvInfo.id as String
+
+        log.debug "Using compute environment: '${computeEnvInfo.name}' (ID: ${computeEnvId})"
+
+        // Use compute environment workDir if not specified on CLI
+        String workDir = options.workDir
+        if (!workDir && computeEnvInfo.workDir) {
+            workDir = computeEnvInfo.workDir as String
+        }
+        if (!workDir) {
+            throw new AbortOperationException("Work directory is required. Please specify -w/--work-dir or ensure your compute environment has a workDir configured.")
+        }
+
+        // Parse parameters
+        log.debug "Building parameters from CLI args and params file"
+        log.debug "CLI params provided: ${options.params}"
+        log.debug "Params file: ${options.paramsFile ?: 'none'}"
+        String paramsText = buildParamsText(options.params, options.paramsFile)
+        if (paramsText) {
+            log.debug "Generated params JSON (${paramsText.length()} chars)"
+        } else {
+            log.debug "No parameters specified"
+        }
+
+        // Build config text
+        log.debug "Building configuration from config files"
+        log.debug "Config files: ${options.configFiles ?: 'none'}"
+        log.debug "Config profile: ${options.profile ?: 'none'}"
+        String configText = buildConfigText(options.configFiles)
+        if (configText) {
+            log.debug "Generated config text (${configText.length()} chars)"
+        } else {
+            log.debug "No configuration files specified"
+        }
+
+        // Build launch request
+        def launch = [:]
+        launch.computeEnvId = computeEnvId
+        launch.workDir = workDir
+        if (options.runName) launch.runName = options.runName
+        launch.pipeline = resolvedPipelineUrl
+        if (options.revision) launch.revision = options.revision
+        if (options.profile) launch.configProfiles = options.profile
+        if (configText) launch.configText = configText
+        if (paramsText) launch.paramsText = paramsText
+        if (options.mainScript) launch.mainScript = options.mainScript
+        if (options.entryName) launch.entryName = options.entryName
+        launch.resume = options.resume != null
+        launch.pullLatest = options.latest
+        launch.stubRun = options.stubRun
+
+        def launchRequest = [launch: launch]
+
+        log.debug "Built launch request with ${launchRequest.launch.size()} parameters"
+
+        // Submit launch request
+        def queryParams = workspaceId ? [workspaceId: workspaceId.toString()] : [:]
+        if (workspaceId) {
+            log.debug "Submitting to workspace ID: ${workspaceId}"
+        } else {
+            log.debug "Submitting to personal workspace (no workspaceId specified)"
+        }
+
+        def response = apiPost('/workflow/launch', launchRequest, queryParams, accessToken, apiEndpoint)
+
+        // Get workflow details to extract accurate launch information
+        def workflowDetails = null
+        if (response.workflowId) {
+            log.debug "Fetching workflow details for ID: ${response.workflowId}"
+            def workflowQueryParams = workspaceId ? [workspaceId: workspaceId.toString()] : [:]
+            workflowDetails = apiGet("/workflow/${response.workflowId}", workflowQueryParams, accessToken, apiEndpoint)
+        }
+
+        // Extract launch information from workflow details
+        def actualRunName = 'unknown'
+        def commitId = 'unknown'
+        def actualRevision = options.revision
+        def actualRepo = resolvedPipelineUrl
+
+        if (workflowDetails?.workflow) {
+            def workflow = workflowDetails.workflow as Map
+            actualRunName = workflow.runName as String ?: options.runName ?: 'unknown'
+            commitId = workflow.commitId as String ?: 'unknown'
+            actualRevision = workflow.revision as String ?: options.revision
+        } else {
+            // Fallback to original data if workflow details not available
+            actualRunName = options.runName ?: 'unknown'
+        }
+
+        // Print launch info line
+        printLaunchInfo(actualRepo, actualRunName, commitId, actualRevision, workDir, computeEnvInfo.name as String, orgName, workspaceName, options)
+
+        // Construct and display tracking URL
+        def trackingUrl = null
+        final webUrl = apiEndpointToWebUrl(apiEndpoint)
+        if (response.workflowId && orgName && workspaceName) {
+            trackingUrl = "${webUrl}/orgs/${orgName}/workspaces/${workspaceName}/watch/${response.workflowId}/"
+        } else if (response.workflowId && userName) {
+            trackingUrl = "${webUrl}/user/${userName}/watch/${response.workflowId}/"
+        }
+
+        printSuccessMessage(response.workflowId as String, trackingUrl, options)
+
+        // Poll for log messages if we have a workflow ID
+        if (response.workflowId) {
+            pollWorkflowLogs(response.workflowId as String, workspaceId, trackingUrl, accessToken, apiEndpoint, options)
+        }
+    }
+
+    protected void printBanner(CmdLaunch.LaunchOptions options) {
+        if (ColorUtil.isAnsiEnabled()) {
+            // Plain header for verbose log
+            log.debug "N E X T F L O W  ~  version ${BuildInfo.version}"
+
+            // Fancy coloured header for the console output
+            println ""
+            // Use exact colour codes matching the Nextflow green brand
+            final BACKGROUND = "\033[1m\033[38;5;232m\033[48;5;43m"
+            print("$BACKGROUND N E X T F L O W ")
+            print("\033[0m")
+
+            // Show Nextflow version and launch context
+            print(ColorUtil.colorize("  ~  ", "dim", true))
+            println("version " + BuildInfo.version)
+            println("Launching workflow in Seqera Platform")
+            println ""
+        } else {
+            // Plain header to the console if ANSI is disabled
+            log.info "N E X T F L O W  ~  version ${BuildInfo.version}"
+            log.info "Launching workflow in Seqera Platform"
+        }
+    }
+
+    protected void printLaunchInfo(String repo, String runName, String commitId, String revision, String workDir, String computeEnvName, String orgName, String workspaceName, CmdLaunch.LaunchOptions options) {
+        def showRevision = commitId && commitId != 'unknown'
+        def showRevisionBrackets = revision && revision != 'unknown'
+
+        if (ColorUtil.isAnsiEnabled()) {
+            def debugMsg = "Launched `${repo}` [${runName}]"
+            if (showRevision) {
+                debugMsg += " - revision: ${commitId}"
+            }
+            if (showRevisionBrackets) {
+                debugMsg += " [${revision}]"
+            }
+            log.debug debugMsg
+
+            print("Launched")
+            print(ColorUtil.colorize(" `$repo` ", "magenta", true))
+            print(ColorUtil.colorize("[", "dim", true))
+            print(ColorUtil.colorize(runName, "cyan bold", true))
+            print(ColorUtil.colorize("]", "dim", true))
+            if (showRevision) {
+                print(" - ")
+                print(ColorUtil.colorize("revision: $commitId", "cyan", true))
+            }
+            if (showRevisionBrackets) {
+                print(ColorUtil.colorize(" [", "dim", true))
+                print(ColorUtil.colorize(revision, "cyan", true))
+                print(ColorUtil.colorize("]", "dim", true))
+            }
+            println ""
+
+            // Print workspace
+            if (orgName && workspaceName) {
+                println(" 🏢 workspace: ${ColorUtil.colorize(orgName + ' / ' + workspaceName, 'cyan', true)}")
+            } else {
+                println(" 🏢 workspace: ${ColorUtil.colorize("Personal workspace", 'cyan', true)}")
+            }
+
+            // Print work directory
+            println(" 📁 workdir: ${ColorUtil.colorize(workDir, 'cyan', true)}")
+
+            // Print compute environment
+            println(" ☁️ compute: ${ColorUtil.colorize(computeEnvName, 'cyan', true)}\n")
+        } else {
+            def plainMsg = "Launched `${repo}` [${runName}]"
+            if (showRevision) {
+                plainMsg += " - revision: ${commitId}"
+            }
+            if (showRevisionBrackets) {
+                plainMsg += " [${revision}]"
+            }
+            log.info plainMsg
+            if (orgName && workspaceName) {
+                log.info " workspace: ${orgName} / ${workspaceName}"
+            } else {
+                log.info " workspace: Personal workspace"
+            }
+            log.info " workdir: ${workDir}"
+            log.info " compute: ${computeEnvName}"
+        }
+    }
+
+    protected void printSuccessMessage(String workflowId, String trackingUrl, CmdLaunch.LaunchOptions options) {
+        if (ColorUtil.isAnsiEnabled()) {
+            if (trackingUrl) {
+                print(ColorUtil.colorize("Workflow launched successfully: ", "green"))
+                ColorUtil.printColored(trackingUrl, "cyan")
+            } else if (workflowId) {
+                ColorUtil.printColored("Workflow launched successfully!", "green")
+                print("Workflow ID: ")
+                ColorUtil.printColored(workflowId, "cyan")
+            } else {
+                ColorUtil.printColored("Workflow launched successfully!", "green")
+            }
+            print(ColorUtil.colorize("💡 To do more with Seqera Platform via the CLI, see ", "dim"))
+            ColorUtil.printColored("https://github.com/seqeralabs/tower-cli/", "cyan bold")
+            println ""
+        } else {
+            if (trackingUrl) {
+                log.info "Workflow launched successfully: ${trackingUrl}"
+            } else if (workflowId) {
+                log.info "Workflow launched successfully!"
+                log.info "Workflow ID: ${workflowId}"
+            } else {
+                log.info "Workflow launched successfully!"
+            }
+            log.info "To do more with Seqera Platform via the CLI, see https://github.com/seqeralabs/tower-cli/"
+        }
+    }
+
+    /**
+     * Poll workflow logs until the workflow completes
+     */
+    private void pollWorkflowLogs(String workflowId, Long workspaceId, String trackingUrl, String accessToken, String apiEndpoint, CmdLaunch.LaunchOptions options) {
+        log.debug "Starting log polling for workflow ID: ${workflowId}"
+
+        def queryParams = workspaceId ? [workspaceId: workspaceId.toString()] : [:]
+        def displayedLogCount = 0
+        def finalStatuses = ['SUCCEEDED', 'FAILED', 'CANCELLED', 'UNKNOWN'] as Set<String>
+        def firstLogReceived = false
+        def workflowFinished = false
+        def workflowFinishedTime = 0L
+
+        // Flag to signal when to stop polling
+        def shouldExit = new AtomicBoolean(false)
+
+        // Add shutdown hook to handle Ctrl+C
+        def shutdownHook = new Thread({
+            shouldExit.set(true)
+            log.debug "Shutdown hook triggered - setting exit flag"
+
+            // Print exit message
+            if (ColorUtil.isAnsiEnabled()) {
+                println ""
+                println "Exiting log viewer."
+                if (trackingUrl) {
+                    print(ColorUtil.colorize("⚠️ Workflow is still running in Seqera Platform: ", "yellow bold"))
+                    ColorUtil.printColored(trackingUrl, "cyan")
+                }
+            } else {
+                log.info "Exiting log viewer."
+                if (trackingUrl) {
+                    log.info "Workflow is still running in Seqera Platform: ${trackingUrl}"
+                }
+            }
+        })
+
+        Runtime.getRuntime().addShutdownHook(shutdownHook)
+
+        // Initial message
+        if (ColorUtil.isAnsiEnabled()) {
+            print(ColorUtil.colorize("Workflow submitted, awaiting log output. It is now safe to exit with ctrl+c", "dim"))
+        } else {
+            log.info "Workflow submitted, awaiting log output. It is now safe to exit with ctrl+c"
+        }
+
+        try {
+            while (!shouldExit.get()) {
+                try {
+                    // Check workflow status
+                    def workflowResponse = apiGet("/workflow/${workflowId}", queryParams, accessToken, apiEndpoint)
+                    def workflow = workflowResponse.workflow as Map
+                    def status = workflow?.status as String
+
+                    log.debug "Workflow status: ${status}"
+
+                    // Poll the log endpoint for new entries
+                    def logResponse = apiGet("/workflow/${workflowId}/log", queryParams, accessToken, apiEndpoint)
+                    def logData = logResponse.log as Map
+
+                    if (logData) {
+                        def entries = logData.entries as List<String>
+
+                        // Display new log entries
+                        if (entries && entries.size() > displayedLogCount) {
+                            // Clear waiting message on first log entry
+                            if (!firstLogReceived) {
+                                firstLogReceived = true
+                                if (ColorUtil.isAnsiEnabled()) {
+                                    println ""
+                                    print('─' * 10)
+                                    println ""
+                                }
+                            }
+
+                            def newEntries = entries.subList(displayedLogCount, entries.size())
+                            for (String entry : newEntries) {
+                                if (shouldExit.get()) break
+                                println entry
+                            }
+                            displayedLogCount = entries.size()
+                        } else if (!firstLogReceived) {
+                            // Show progress dots while waiting
+                            if (ColorUtil.isAnsiEnabled()) {
+                                print(ColorUtil.colorize(".", "dim", true))
+                            }
+                            System.out.flush()
+                        }
+                    }
+
+                    // Check if workflow has reached a final status
+                    if (status && finalStatuses.contains(status)) {
+                        if (!workflowFinished) {
+                            log.debug "Workflow reached final status: ${status}, continuing to poll for 5 more seconds to capture remaining logs"
+                            workflowFinished = true
+                            workflowFinishedTime = System.currentTimeMillis()
+                        }
+                    }
+
+                    // Check if we should stop polling (5 seconds after workflow finished)
+                    if (workflowFinished && (System.currentTimeMillis() - workflowFinishedTime) > 5000) {
+                        log.debug "Grace period elapsed, stopping log polling"
+                        break
+                    }
+
+                    // Wait 2 seconds before next API poll
+                    for (int i = 0; i < 20 && !shouldExit.get(); i++) {
+                        Thread.sleep(100)
+                    }
+
+                } catch (Exception e) {
+                    if (shouldExit.get()) break
+                    log.error "Error polling workflow logs: ${e.message}", e
+                    // Continue polling despite errors (wait 2 seconds)
+                    for (int i = 0; i < 20 && !shouldExit.get(); i++) {
+                        Thread.sleep(100)
+                    }
+                }
+            }
+        } finally {
+            // Remove shutdown hook if we exit normally
+            try {
+                Runtime.getRuntime().removeShutdownHook(shutdownHook)
+            } catch (IllegalStateException e) {
+                // Shutdown hook already executed, ignore
+            }
+        }
+
+        log.debug "Log polling completed for workflow ID: ${workflowId}"
+    }
+
+    private static boolean isLocalPath(String path) {
+        if (path.startsWith('/') || path.startsWith('./') || path.startsWith('../')) {
+            return true
+        }
+        if (path.contains('\\') || path ==~ /^[A-Za-z]:.*/) {
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Convert API endpoint URL to web UI URL
+     * Examples:
+     *   https://api.cloud.seqera.io -> https://cloud.seqera.io
+     *   https://api.cloud.stage-seqera.io -> https://cloud.stage-seqera.io
+     *   https://tower.example.com/api -> https://tower.example.com
+     */
+    private static String apiEndpointToWebUrl(String apiEndpoint) {
+        // Remove /api suffix if present
+        def webUrl = apiEndpoint.replaceFirst('/api$', '')
+
+        // Convert api.cloud.* pattern to cloud.* pattern
+        webUrl = webUrl.replaceFirst('://api\\.', '://')
+
+        return webUrl
+    }
+
+    private String buildParamsText(Map<String, String> params, String paramsFile) {
+        final result = [:]
+
+        // Apply params file
+        if (paramsFile) {
+            log.debug "Processing params file: ${paramsFile}"
+            def path = validateParamsFile(paramsFile)
+            def type = path.extension.toLowerCase() ?: null
+            if (type == 'json') {
+                log.debug "Reading JSON params file: ${paramsFile}"
+                readJsonFile(path, result)
+            } else if (type == 'yml' || type == 'yaml') {
+                log.debug "Reading YAML params file: ${paramsFile}"
+                readYamlFile(path, result)
+            }
+            log.debug "Loaded ${result.size()} parameters from file"
+        }
+
+        // Apply CLI params
+        if (params) {
+            log.debug "Processing ${params.size()} CLI parameters"
+            for (Map.Entry<String, String> entry : params) {
+                log.trace "Adding parameter: ${entry.key} = ${entry.value}"
+                addParam(result, entry.key, entry.value)
+            }
+            log.debug "Total parameters after CLI merge: ${result.size()}"
+        }
+
+        if (result.isEmpty()) {
+            log.debug "No parameters to include in launch request"
+            return null
+        }
+
+        // Convert to JSON
+        def jsonBuilder = new JsonBuilder(result)
+        def jsonText = jsonBuilder.toString()
+        log.debug "Converted ${result.size()} parameters to JSON format"
+        return jsonText
+    }
+
+    private String buildConfigText(List<String> configFiles) {
+        if (!configFiles || configFiles.isEmpty()) {
+            log.debug "No configuration files specified"
+            return null
+        }
+
+        log.debug "Processing ${configFiles.size()} configuration files"
+        def configText = new StringBuilder()
+        for (String configFile : configFiles) {
+            log.debug "Reading config file: ${configFile}"
+            def path = FileHelper.asPath(configFile)
+            if (!path.exists()) {
+                log.debug "Config file not found: ${configFile}"
+                throw new AbortOperationException("Config file not found: ${configFile}")
+            }
+            def content = path.text
+            log.debug "Read ${content.length()} characters from config file: ${configFile}"
+            configText.append(content).append('\n')
+        }
+
+        log.debug "Combined configuration text: ${configText.length()} characters"
+        return configText.toString()
+    }
+
+    private Path validateParamsFile(String file) {
+        def result = FileHelper.asPath(file)
+        def ext = result.getExtension()
+        if (!VALID_PARAMS_FILE.contains(ext)) {
+            throw new AbortOperationException("Not a valid params file extension: $file -- It must be one of the following: ${VALID_PARAMS_FILE.join(',')}")
+        }
+        return result
+    }
+
+    private void readJsonFile(Path file, Map result) {
+        try {
+            def json = (Map<String, Object>) new JsonSlurper().parseText(file.text)
+            json.forEach((name, value) -> {
+                addParam0(result, name, value)
+            })
+        } catch (NoSuchFileException | FileNotFoundException e) {
+            throw new AbortOperationException("Specified params file does not exist: ${file.toUriString()}")
+        } catch (Exception e) {
+            throw new AbortOperationException("Cannot parse params file: ${file.toUriString()} - Cause: ${e.message}", e)
+        }
+    }
+
+    private void readYamlFile(Path file, Map result) {
+        try {
+            def yaml = (Map<String, Object>) new Yaml().load(file.text)
+            yaml.forEach((name, value) -> {
+                addParam0(result, name, value)
+            })
+        } catch (NoSuchFileException | FileNotFoundException e) {
+            throw new AbortOperationException("Specified params file does not exist: ${file.toUriString()}")
+        } catch (Exception e) {
+            throw new AbortOperationException("Cannot parse params file: ${file.toUriString()}", e)
+        }
+    }
+
+    private static void addParam(Map params, String key, String value, List path = [], String fullKey = null) {
+        if (!fullKey) {
+            fullKey = key
+        }
+        final m = DOT_NOT_ESCAPED.matcher(key)
+        if (m.find()) {
+            final p = m.start()
+            final root = key.substring(0, p)
+            if (!root) throw new AbortOperationException("Invalid parameter name: $fullKey")
+            path.add(root)
+            def nested = params.get(root)
+            if (nested == null) {
+                nested = new LinkedHashMap<>()
+                params.put(root, nested)
+            } else if (!(nested instanceof Map)) {
+                log.warn "Command line parameter --${path.join('.')} is overwritten by --${fullKey}"
+                nested = new LinkedHashMap<>()
+                params.put(root, nested)
+            }
+            addParam((Map) nested, key.substring(p + 1), value, path, fullKey)
+        } else {
+            addParam0(params, key.replaceAll(DOT_ESCAPED, '.'), parseParamValue(value))
+        }
+    }
+
+    private static void addParam0(Map params, String key, Object value) {
+        if (key.contains('-')) {
+            key = kebabToCamelCase(key)
+        }
+        params.put(key, value)
+    }
+
+    private static String kebabToCamelCase(String str) {
+        final result = new StringBuilder()
+        str.split('-').eachWithIndex { String entry, int i ->
+            result << (i > 0 ? entry.capitalize() : entry)
+        }
+        return result.toString()
+    }
+
+    private static Object parseParamValue(String str) {
+        if (str == null) return null
+
+        if (str.toLowerCase() == 'true') return Boolean.TRUE
+        if (str.toLowerCase() == 'false') return Boolean.FALSE
+
+        if (str ==~ /-?\d+(\.\d+)?/ && str.isInteger()) return str.toInteger()
+        if (str ==~ /-?\d+(\.\d+)?/ && str.isLong()) return str.toLong()
+        if (str ==~ /-?\d+(\.\d+)?/ && str.isDouble()) return str.toDouble()
+
+        return str
+    }
+
+    /**
+     * Resolve pipeline name to full repository URL using AssetManager
+     */
+    private String resolvePipelineUrl(String pipelineName) {
+        try {
+            log.debug "Resolving pipeline name using AssetManager: ${pipelineName}"
+            def assetManager = new AssetManager(pipelineName)
+            def repositoryUrl = assetManager.getRepositoryUrl()
+            if (repositoryUrl) {
+                log.debug "AssetManager resolved URL: ${repositoryUrl}"
+                return repositoryUrl
+            } else {
+                log.debug "AssetManager could not resolve URL, using original name: ${pipelineName}"
+                return pipelineName
+            }
+        } catch (Exception e) {
+            log.debug "Failed to resolve pipeline URL with AssetManager: ${e.message}, using original name: ${pipelineName}"
+            return pipelineName
+        }
+    }
+
+    // ===== API Helper Methods =====
+
+    protected HxClient createHttpClient(String authToken = null) {
+        final builder = HxClient.newBuilder()
+            .connectTimeout(Duration.ofMillis(API_TIMEOUT_MS))
+
+        if (authToken) {
+            builder.bearerToken(authToken)
+        }
+
+        return builder.build()
+    }
+
+    protected Map apiGet(String path, Map queryParams = [:], String accessToken, String apiEndpoint) {
+        final url = buildUrl(apiEndpoint, path, queryParams)
+        final client = createHttpClient(accessToken)
+        final request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .GET()
+            .build()
+
+        final response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            final error = response.body() ?: "HTTP ${response.statusCode()}"
+            throw new RuntimeException("API request failed: ${error}")
+        }
+
+        return new JsonSlurper().parseText(response.body()) as Map
+    }
+
+    protected Map apiPost(String path, Map body, Map queryParams = [:], String accessToken, String apiEndpoint) {
+        final url = buildUrl(apiEndpoint, path, queryParams)
+        final requestBody = new JsonBuilder(body).toString()
+        final client = createHttpClient(accessToken)
+        final request = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .header('Content-Type', 'application/json')
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+            .build()
+
+        final response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            final error = response.body() ?: "HTTP ${response.statusCode()}"
+            throw new RuntimeException("Failed to launch workflow: ${error}")
+        }
+
+        return new JsonSlurper().parseText(response.body()) as Map
+    }
+
+    private String buildUrl(String endpoint, String path, Map queryParams) {
+        def url = new StringBuilder(endpoint)
+        if (!path.startsWith('/')) {
+            url.append('/')
+        }
+        url.append(path)
+
+        if (queryParams && !queryParams.isEmpty()) {
+            url.append('?')
+            url.append(queryParams.collect { k, v -> "${URLEncoder.encode(k.toString(), 'UTF-8')}=${URLEncoder.encode(v.toString(), 'UTF-8')}" }.join('&'))
+        }
+
+        return url.toString()
+    }
+
+    private Map readConfig() {
+        final builder = new ConfigBuilder()
+        return builder.buildConfigObject().flatten()
+    }
+
+    private Long resolveWorkspaceId(Map config, String workspaceName, String accessToken, String apiEndpoint) {
+        // First check config for workspace ID
+        final configWorkspaceId = config['tower.workspaceId']
+        if (configWorkspaceId) {
+            return configWorkspaceId as Long
+        }
+
+        // If workspace name provided, look it up
+        if (workspaceName) {
+            final userId = getUserId(accessToken, apiEndpoint)
+            final workspaces = getUserWorkspaces(accessToken, apiEndpoint, userId)
+            final workspace = workspaces.find { ((Map) it).workspaceName == workspaceName }
+            if (workspace) {
+                return ((Map) workspace).workspaceId as Long
+            }
+            throw new AbortOperationException("Workspace '${workspaceName}' not found")
+        }
+
+        return null
+    }
+
+    private String getUserName(String accessToken, String apiEndpoint) {
+        final userInfo = callUserInfoApi(accessToken, apiEndpoint)
+        return userInfo.userName as String
+    }
+
+    private String getUserId(String accessToken, String apiEndpoint) {
+        final userInfo = callUserInfoApi(accessToken, apiEndpoint)
+        return userInfo.id as String
+    }
+
+    private Map callUserInfoApi(String accessToken, String apiEndpoint) {
+        final client = createHttpClient(accessToken)
+        final request = HttpRequest.newBuilder()
+            .uri(URI.create("${apiEndpoint}/user-info"))
+            .GET()
+            .build()
+
+        final response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            final error = response.body() ?: "HTTP ${response.statusCode()}"
+            throw new RuntimeException("Failed to get user info: ${error}")
+        }
+
+        final json = new JsonSlurper().parseText(response.body()) as Map
+        return json.user as Map
+    }
+
+    private List getUserWorkspaces(String accessToken, String apiEndpoint, String userId) {
+        final client = createHttpClient(accessToken)
+        final request = HttpRequest.newBuilder()
+            .uri(URI.create("${apiEndpoint}/user/${userId}/workspaces"))
+            .GET()
+            .build()
+
+        final response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            final error = response.body() ?: "HTTP ${response.statusCode()}"
+            throw new RuntimeException("Failed to get workspaces: ${error}")
+        }
+
+        final json = new JsonSlurper().parseText(response.body()) as Map
+        final orgsAndWorkspaces = json.orgsAndWorkspaces as List
+
+        return orgsAndWorkspaces.findAll { ((Map) it).workspaceId != null }
+    }
+
+    private Map getWorkspaceDetails(String accessToken, String apiEndpoint, Long workspaceId) {
+        try {
+            final userId = getUserId(accessToken, apiEndpoint)
+            final workspaces = getUserWorkspaces(accessToken, apiEndpoint, userId)
+            final workspace = workspaces.find { ((Map) it).workspaceId?.toString() == workspaceId?.toString() }
+            if (workspace) {
+                final ws = workspace as Map
+                return [
+                    orgName: ws.orgName,
+                    workspaceName: ws.workspaceName,
+                    workspaceFullName: ws.workspaceFullName
+                ]
+            }
+            return null
+        } catch (Exception e) {
+            log.debug "Failed to get workspace details: ${e.message}"
+            return null
+        }
+    }
+
+    private Map findComputeEnv(String computeEnvName, Long workspaceId, String accessToken, String apiEndpoint) {
+        final computeEnvs = getComputeEnvs(workspaceId, accessToken, apiEndpoint)
+
+        log.debug "Looking for ${computeEnvName ? "compute environment with name: ${computeEnvName}" : "primary compute environment"} ${workspaceId ? "in workspace ID ${workspaceId}" : "in personal workspace"}"
+
+        for (item in computeEnvs) {
+            final computeEnv = item as Map
+            if ((computeEnvName && computeEnv.name == computeEnvName) || (!computeEnvName && computeEnv.primary == true)) {
+                log.debug "Found ${computeEnvName ? "matching" : "primary"} compute environment '${computeEnv.name}' (ID: ${computeEnv.id})"
+                return computeEnv
+            }
+        }
+
+        return null
+    }
+
+    private List getComputeEnvs(Long workspaceId, String accessToken, String apiEndpoint) {
+        def path = workspaceId ? "/compute-envs?workspaceId=${workspaceId}" : "/compute-envs"
+
+        final client = createHttpClient(accessToken)
+        final request = HttpRequest.newBuilder()
+            .uri(URI.create("${apiEndpoint}${path}"))
+            .GET()
+            .build()
+
+        final response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != 200) {
+            final error = response.body() ?: "HTTP ${response.statusCode()}"
+            throw new RuntimeException("Failed to get compute environments: ${error}")
+        }
+
+        final json = new JsonSlurper().parseText(response.body()) as Map
+        return json.computeEnvs as List ?: []
+    }
+}

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
@@ -200,7 +200,7 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
         }
 
         // Print launch info line
-        printLaunchInfo(actualRepo, actualRunName, commitId, actualRevision, workDir, computeEnvInfo.name as String, orgName, workspaceName, options)
+        printLaunchInfo(actualRepo, actualRunName, commitId, actualRevision, workDir, computeEnvInfo.name as String, userName, orgName, workspaceName, options)
 
         // Construct and display tracking URL
         def trackingUrl = null
@@ -243,7 +243,7 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
         }
     }
 
-    protected void printLaunchInfo(String repo, String runName, String commitId, String revision, String workDir, String computeEnvName, String orgName, String workspaceName, CmdLaunch.LaunchOptions options) {
+    protected void printLaunchInfo(String repo, String runName, String commitId, String revision, String workDir, String computeEnvName, String userName, String orgName, String workspaceName, CmdLaunch.LaunchOptions options) {
         def showRevision = commitId && commitId != 'unknown'
         def showRevisionBrackets = revision && revision != 'unknown'
 
@@ -273,6 +273,11 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
             }
             println ""
 
+            // Print username
+            if (userName) {
+                println(" 👤 user: ${ColorUtil.colorize(userName, 'cyan', true)}")
+            }
+
             // Print workspace
             if (orgName && workspaceName) {
                 println(" 🏢 workspace: ${ColorUtil.colorize(orgName + ' / ' + workspaceName, 'cyan', true)}")
@@ -294,6 +299,9 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
                 plainMsg += " [${revision}]"
             }
             log.info plainMsg
+            if (userName) {
+                log.info " user: ${userName}"
+            }
             if (orgName && workspaceName) {
                 log.info " workspace: ${orgName} / ${workspaceName}"
             } else {

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/LaunchCommandImpl.groovy
@@ -512,8 +512,8 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
 
                     // Update spinner with status if it changed
                     if (status && status != lastStatus) {
-                        def isWaiting = (status == 'PENDING' || status == 'SUBMITTED')
-                        spinner.updateMessage(formatWorkflowStatus(status), getColorForStatus(status), isWaiting)
+                        def spinnerMode = getSpinnerMode(status, workflowFinished)
+                        spinner.updateMessage(formatWorkflowStatus(status), getColorForStatus(status), spinnerMode)
                         lastStatus = status
                     }
 
@@ -571,6 +571,26 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
     }
 
     /**
+     * Get the spinner mode for a workflow status
+     */
+    private String getSpinnerMode(String status, boolean workflowFinished) {
+        if (!status) return 'waiting'
+
+        // Use finished animation for final statuses
+        if (status == 'SUCCEEDED' || status == 'FAILED' || status == 'CANCELLED' || status == 'ABORTED' || status == 'UNKNOWN') {
+            return 'finished'
+        }
+
+        // Use waiting animation for pending/submitted
+        if (status == 'PENDING' || status == 'SUBMITTED') {
+            return 'waiting'
+        }
+
+        // Use running animation for all other active states (RUNNING, etc.)
+        return 'running'
+    }
+
+    /**
      * Get the color name for a workflow status
      */
     private String getColorForStatus(String status) {
@@ -584,10 +604,10 @@ class LaunchCommandImpl implements CmdLaunch.LaunchCommand {
                 return 'blue'
             case 'FAILED':
             case 'ABORTED':
+            case 'CANCELLED':
                 return 'red'
             case 'SUCCEEDED':
                 return 'green'
-            case 'CANCELLED':
             default:
                 return 'cyan'
         }

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2013-2025, Seqera Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.seqera.tower.plugin.cli
+
+import groovy.transform.CompileStatic
+import nextflow.cli.ColorUtil
+import org.fusesource.jansi.Ansi
+import org.fusesource.jansi.AnsiConsole
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import static org.fusesource.jansi.Ansi.Erase
+
+/**
+ * Spinner utility for showing animated progress indicators
+ *
+ * Usage:
+ * <pre>
+ * def spinner = new SpinnerUtil("Loading...")
+ * spinner.start()
+ * try {
+ *     // Do work
+ *     spinner.updateMessage("Still loading...")
+ * } finally {
+ *     spinner.stop()
+ * }
+ * </pre>
+ *
+ * Or use the withSpinner method for automatic cleanup:
+ * <pre>
+ * SpinnerUtil.withSpinner("Loading...") { spinner ->
+ *     // Do work
+ *     spinner.updateMessage("Still loading...")
+ * }
+ * </pre>
+ *
+ * @author Phil Ewels <phil.ewels@seqera.io>
+ */
+@CompileStatic
+class SpinnerUtil {
+
+    private static final String[] SPINNER_CHARS = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as String[]
+    private static final int SPINNER_UPDATE_MS = 100 // Update spinner every 100ms for smooth animation
+
+    private final AtomicBoolean shouldStop = new AtomicBoolean(false)
+    private String message
+    private Thread spinnerThread
+    private final boolean ansiEnabled
+    private volatile int spinnerIndex = 0
+
+    /**
+     * Create a new spinner with the given message
+     *
+     * @param message The message to display next to the spinner
+     */
+    SpinnerUtil(String message) {
+        this.message = message
+        this.ansiEnabled = ColorUtil.isAnsiEnabled()
+    }
+
+    /**
+     * Start the spinner animation in a background thread
+     */
+    void start() {
+        if (!ansiEnabled || spinnerThread != null) {
+            return
+        }
+
+        shouldStop.set(false)
+        spinnerThread = new Thread({
+            try {
+                while (!shouldStop.get()) {
+                    def fmt = Ansi.ansi()
+                    fmt.a("\r").eraseLine(Erase.ALL)
+                    fmt.fg(Ansi.Color.CYAN).a(SPINNER_CHARS[spinnerIndex]).reset()
+                    fmt.a(" ").a(message)
+                    AnsiConsole.out.print(fmt.toString())
+                    AnsiConsole.out.flush()
+                    spinnerIndex = (spinnerIndex + 1) % SPINNER_CHARS.length
+                    Thread.sleep(SPINNER_UPDATE_MS)
+                }
+            } catch (InterruptedException e) {
+                // Thread interrupted, exit gracefully
+            } catch (Exception e) {
+                // Ignore other errors to prevent spinner from breaking the main application
+            }
+        })
+        spinnerThread.daemon = true
+        spinnerThread.start()
+    }
+
+    /**
+     * Update the message displayed next to the spinner
+     *
+     * @param newMessage The new message to display
+     */
+    void updateMessage(String newMessage) {
+        this.message = newMessage
+    }
+
+    /**
+     * Stop the spinner and clear the line
+     *
+     * @param clearLine If true, clears the spinner line completely. If false, leaves the last message visible
+     */
+    void stop(boolean clearLine = true) {
+        shouldStop.set(true)
+
+        if (spinnerThread != null && spinnerThread.isAlive()) {
+            try {
+                spinnerThread.join(200) // Wait up to 200ms for spinner to stop
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        }
+
+        if (ansiEnabled && clearLine) {
+            def fmt = Ansi.ansi()
+            fmt.a("\r").eraseLine(Erase.ALL)
+            AnsiConsole.out.print(fmt.toString())
+            AnsiConsole.out.flush()
+        }
+
+        spinnerThread = null
+    }
+
+    /**
+     * Stop the spinner and replace it with a final message
+     *
+     * @param finalMessage The final message to display (will be printed on a new line)
+     */
+    void stopWithMessage(String finalMessage) {
+        shouldStop.set(true)
+
+        if (spinnerThread != null && spinnerThread.isAlive()) {
+            try {
+                spinnerThread.join(200)
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        }
+
+        if (ansiEnabled) {
+            def fmt = Ansi.ansi()
+            fmt.a("\r").eraseLine(Erase.ALL)
+            fmt.a(finalMessage).a("\n")
+            AnsiConsole.out.print(fmt.toString())
+            AnsiConsole.out.flush()
+        } else {
+            println finalMessage
+        }
+
+        spinnerThread = null
+    }
+
+    /**
+     * Check if the spinner is currently running
+     */
+    boolean isRunning() {
+        return spinnerThread != null && spinnerThread.isAlive() && !shouldStop.get()
+    }
+
+    /**
+     * Execute a closure with a spinner, automatically cleaning up when done
+     *
+     * @param message The message to display
+     * @param closure The code to execute while the spinner is running
+     */
+    static void withSpinner(String message, Closure closure) {
+        def spinner = new SpinnerUtil(message)
+        spinner.start()
+        try {
+            closure.call(spinner)
+        } finally {
+            spinner.stop()
+        }
+    }
+}

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
@@ -53,9 +53,10 @@ import static org.fusesource.jansi.Ansi.Erase
 @CompileStatic
 class SpinnerUtil {
 
+    private static final String[] SPINNER_CHARS_WAITING = ['⠋', '⠉', '⠙', '⠘', '⠐', '⠘', '⠙', '⠉', '⠋', '⠃', '⠂', '⠃'] as String[]
     private static final String[] SPINNER_CHARS_RUNNING = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as String[]
-    private static final String[] SPINNER_CHARS_WAITING = ['⠋', '⠙', '⠹', '⠸', '⠹', '⠙', '⠋', '⠏', '⠇', '⠏'] as String[]
-    private static final String[] SPINNER_CHARS_FINISHED = ['⢀', '⣀', '⣄', '⣤', '⣦', '⣶', '⣷', '⣿', '⠿', '⠟', '⠛', '⠙', '⠉', '⠁', '⠀'] as String[]
+    private static final String[] SPINNER_CHARS_SUCCEEDED = ['⠀','⠄','⠤','⠦','⠶','⠷','⠿','⠻','⠛','⠙','⠉','⠈'] as String[]
+    private static final String[] SPINNER_CHARS_FAILED = ['⠈', '⠉', '⠙', '⠛', '⠻', '⠿', '⠷', '⠶', '⠦', '⠤', '⠄', '⠀'] as String[]
     private static final int SPINNER_UPDATE_MS = 100 // Update spinner every 100ms for smooth animation
 
     private final AtomicBoolean shouldStop = new AtomicBoolean(false)
@@ -149,7 +150,7 @@ class SpinnerUtil {
      *
      * @param newMessage The new message to display
      * @param newColorName The new color name for the spinner character (e.g., 'yellow', 'blue', 'red')
-     * @param mode The spinner mode: 'waiting', 'running', or 'finished'
+     * @param mode The spinner mode: 'waiting', 'running', 'succeeded', or 'failed'
      */
     void updateMessage(String newMessage, String newColorName, String mode) {
         this.message = newMessage
@@ -159,8 +160,11 @@ class SpinnerUtil {
             case 'waiting':
                 this.spinnerChars = SPINNER_CHARS_WAITING
                 break
-            case 'finished':
-                this.spinnerChars = SPINNER_CHARS_FINISHED
+            case 'succeeded':
+                this.spinnerChars = SPINNER_CHARS_SUCCEEDED
+                break
+            case 'failed':
+                this.spinnerChars = SPINNER_CHARS_FAILED
                 break
             case 'running':
             default:

--- a/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
+++ b/plugins/nf-tower/src/main/io/seqera/tower/plugin/cli/SpinnerUtil.groovy
@@ -55,6 +55,7 @@ class SpinnerUtil {
 
     private static final String[] SPINNER_CHARS_RUNNING = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as String[]
     private static final String[] SPINNER_CHARS_WAITING = ['⠋', '⠙', '⠹', '⠸', '⠹', '⠙', '⠋', '⠏', '⠇', '⠏'] as String[]
+    private static final String[] SPINNER_CHARS_FINISHED = ['⢀', '⣀', '⣄', '⣤', '⣦', '⣶', '⣷', '⣿', '⠿', '⠟', '⠛', '⠙', '⠉', '⠁', '⠀'] as String[]
     private static final int SPINNER_UPDATE_MS = 100 // Update spinner every 100ms for smooth animation
 
     private final AtomicBoolean shouldStop = new AtomicBoolean(false)
@@ -140,6 +141,33 @@ class SpinnerUtil {
         this.message = newMessage
         this.colorName = newColorName
         this.spinnerChars = waiting ? SPINNER_CHARS_WAITING : SPINNER_CHARS_RUNNING
+        this.spinnerIndex = 0 // Reset animation when changing mode
+    }
+
+    /**
+     * Update the message, color, and mode of the spinner with string mode
+     *
+     * @param newMessage The new message to display
+     * @param newColorName The new color name for the spinner character (e.g., 'yellow', 'blue', 'red')
+     * @param mode The spinner mode: 'waiting', 'running', or 'finished'
+     */
+    void updateMessage(String newMessage, String newColorName, String mode) {
+        this.message = newMessage
+        this.colorName = newColorName
+
+        switch (mode) {
+            case 'waiting':
+                this.spinnerChars = SPINNER_CHARS_WAITING
+                break
+            case 'finished':
+                this.spinnerChars = SPINNER_CHARS_FINISHED
+                break
+            case 'running':
+            default:
+                this.spinnerChars = SPINNER_CHARS_RUNNING
+                break
+        }
+
         this.spinnerIndex = 0 // Reset animation when changing mode
     }
 


### PR DESCRIPTION
First stab at re-writing the new `nextflow launch` command. Builds off the new `auth` commands in https://github.com/nextflow-io/nextflow/pull/6380

Stacked PR, opened it here for initial review so that the diff doesn't get too big. Will reopen it against the main Nextflow repo once https://github.com/nextflow-io/nextflow/pull/6380 is merged.

This PR includes:

* New `nextflow launch` command
    * Simple: only works with remote assets, so needs remote paths etc
    * Handles config parsing to pass on parameters and config profiles
* New spinner animation that plays whilst waiting for remote calls
    * Used when launching pipelines, shows pipeline status
    * Also used in auth code when waiting for auth0 completion

Overview video showing `nextflow launch` in action:

https://github.com/user-attachments/assets/e102dc6a-52e9-4acc-a323-a3108227029f

